### PR TITLE
Added the convex optimisation reading group.

### DIFF
--- a/_data/readinggroups.json
+++ b/_data/readinggroups.json
@@ -10,6 +10,17 @@
             }
         ]
     },
+	{
+		"name":"Convex Optimisation",
+		"link":"/reading-groups/convex/",
+		"people":[
+			{
+				"prefix":"",
+				"firstname":"Patrick",
+				"lastname":"O'Hara"
+			}
+		]
+	},
     {
         "name":"Statistical Machine Learning Reading Group",
         "link":"https://warwick.ac.uk/fac/sci/statistics/news/mlrg/",

--- a/convex.markdown
+++ b/convex.markdown
@@ -1,7 +1,8 @@
 ---
 title: Convex Optimisation
-layout: default
-permalink: /convex/
+layout: readinggroup
+permalink: /reading-groups/convex/
+mathjax: False
 ---
 
 # Convex Optimisation Reading Group


### PR DESCRIPTION
It should now link from the reading groups page.